### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/hoogle-data/bloomfilter/2.0.1.0/doc/html/bloomfilter.txt
+++ b/hoogle-data/bloomfilter/2.0.1.0/doc/html/bloomfilter.txt
@@ -85,7 +85,7 @@ hashes :: Hashable a => Int -> a -> [Word32]
 --   
 --   We use a variant of Kirsch and Mitzenmacher's technique from "Less
 --   Hashing, Same Performance: Building a Better Bloom Filter",
---   <a>http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf</a>.
+--   <a>https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf</a>.
 --   
 --   Where Kirsch and Mitzenmacher multiply the second hash by a
 --   coefficient, we shift right by the coefficient. This offers better


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author